### PR TITLE
 fix building on void linux 

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -333,6 +333,7 @@ int checkgammaramp(lua_State *L, int arg, GLFWgammaramp *ramp)
  *------------------------------------------------------------------------------*/
 
 #if defined(LINUX) || defined(MACOS)
+#include <sys/time.h>
 #include <unistd.h> /* for usleep */
 
 #if 0


### PR DESCRIPTION
When I tried to build moonglfw on Void Linux I got an error 
`utils.c:359:20: error: storage size of 'tv' isn't known`
To fix it, I added the missing <sys/time.h> include